### PR TITLE
ROWY-954: Quick-Fix - GitHub Sign-in Issue in Roadmap App

### DIFF
--- a/app/models/User.ts
+++ b/app/models/User.ts
@@ -3,8 +3,8 @@ import type { DecodedIdToken } from "firebase-admin/auth";
 
 export class ClientUser {
   constructor(
-    readonly displayName: string,
     readonly photoURL: string,
+    readonly displayName?: string,
     readonly date?: Date
   ) {}
 }


### PR DESCRIPTION
This PR fixes the bug, as seen in this GitHub Discussion: https://github.com/rowyio/rowy/discussions/1122. The Roadmap app currently gives a runtime error when logged in via GitHub.

Fix: Set the displayName variable to have optional value.

